### PR TITLE
Endpoint listado habilidades/tecnologías, el commit anterior con el mismo nombre debería llamarse tipologías de consultas

### DIFF
--- a/back/src/controllers/expert/selectExpertSkillController.js
+++ b/back/src/controllers/expert/selectExpertSkillController.js
@@ -1,0 +1,18 @@
+import selectDistinctSkillsModel from "../../models/skills/selectDistinctSkillsModel.js";
+
+const selectExpertSkillController = async (req, res, next) => {
+
+    try {
+        const skillsDistinct = await selectDistinctSkillsModel();
+
+        res.status(201).send({
+            status:'ok',
+            message:'Skills in dt ExpertSkillsV1',
+            skills: skillsDistinct
+        });
+    
+    } catch (err) {
+        next(err);
+    }
+};
+export { selectExpertSkillController};

--- a/back/src/models/skills/selectDistinctSkillsModel.js
+++ b/back/src/models/skills/selectDistinctSkillsModel.js
@@ -1,0 +1,15 @@
+import getConnection from "../../db/getConnection.js";
+
+// select all skills in db
+const selectDistinctSkillsModel = async () => {
+
+    const connection = await getConnection();
+
+    const [rows] = await connection.query(
+        `SELECT skill FROM ExpertSkillsV1 ORDER BY skill ASC`
+    );
+
+    // send response
+    return rows.map(row => row.skill);
+};
+export default selectDistinctSkillsModel;

--- a/back/src/routes/skillRouter.js
+++ b/back/src/routes/skillRouter.js
@@ -2,14 +2,16 @@ import express from 'express';
 
 import authUser from '../middlewares/auth.js';
 import newExpertSkillController from '../controllers/expert/newExpertSkillController.js';
-//import { selectExpertSkillController } from '../controllers/expert/selectExpertSkillController.js';
+import { selectExpertSkillController } from '../controllers/expert/selectExpertSkillController.js';
 
 const router = express.Router();
+
+// TODO si queremos q solo un user Experto pueda crear una skill faltaría controlarlo
 
 //* Endpoint para crear una nueva habilidad/tecnología/Skill
 router.post('/newexpertskill', authUser, newExpertSkillController);
 
 //* Endpoint listado habilidades/tecnologías
-//router.get('/expertskills', selectExpertSkillController);
+router.get('/expertskills', selectExpertSkillController);
 
 export default router;


### PR DESCRIPTION
Github cortó el título del commit: 
Endpoint listado habilidades/tecnologías, el commit anterior con el mismo nombre debería llamarse Endpoint listado tipologías de consultas
